### PR TITLE
Add django-cors-headers to allow requests from other domains

### DIFF
--- a/mysite/settings.py
+++ b/mysite/settings.py
@@ -15,6 +15,8 @@ DEBUG = True
 
 ALLOWED_HOSTS = []
 
+CORS_ORIGIN_ALLOW_ALL = True
+
 # Application definition
 
 INSTALLED_APPS = [
@@ -148,12 +150,6 @@ USE_I18N = True
 USE_L10N = True
 
 USE_TZ = True
-
-
-# CORS headers
-# https://github.com/ottoyiu/django-cors-headers
-
-CORS_ORIGIN_ALLOW_ALL = True
 
 
 # Static files (CSS, JavaScript, Images)

--- a/mysite/settings.py
+++ b/mysite/settings.py
@@ -26,6 +26,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'corsheaders',
     'rest_framework',
     'django_extensions',
     'behave_django',
@@ -35,6 +36,7 @@ INSTALLED_APPS = [
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -146,6 +148,12 @@ USE_I18N = True
 USE_L10N = True
 
 USE_TZ = True
+
+
+# CORS headers
+# https://github.com/ottoyiu/django-cors-headers
+
+CORS_ORIGIN_ALLOW_ALL = True
 
 
 # Static files (CSS, JavaScript, Images)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
+## The following requirements were added by pip freeze:
 astroid==1.5.3
 behave==1.2.5
 behave-django==0.5.0
 Django==1.11.5
+django-cors-headers==2.1.0
 django-extensions==1.9.6
 django-parler==1.8
 djangorestframework==3.7.0


### PR DESCRIPTION
Browsers are very persnickety about cross-origin HTTP requests. When our web app tries to do a fetch from the API, there's a preflight OPTIONS request, and we need our app to say "yup, this is okay". This adds a module which does that for us, and some very open-ended initial configuration.