### PR TITLE
Issue #170 Create PostGIS integration on Heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-release: ./release-tasks.sh
+release: python manage.py migrate
 web: gunicorn config.wsgi:application --log-file -

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
+release: ./release-tasks.sh
 web: gunicorn config.wsgi:application --log-file -

--- a/app.json
+++ b/app.json
@@ -38,7 +38,8 @@
   ],
   "buildpacks": [
     {
-      "url": "heroku/python"
+      "url": "heroku/python",
+      "url": "https://github.com/dschep/heroku-geo-buildpack.git"
     }
   ]
 }

--- a/app.json
+++ b/app.json
@@ -38,8 +38,10 @@
   ],
   "buildpacks": [
     {
-      "url": "heroku/python",
       "url": "https://github.com/dschep/heroku-geo-buildpack.git"
+    },
+    {
+      "url": "heroku/python"
     }
   ]
 }

--- a/config/settings/production_heroku.py
+++ b/config/settings/production_heroku.py
@@ -1,0 +1,5 @@
+from .production import *
+
+GDAL_LIBRARY_PATH = '/app/.heroku/vendor/lib/libgdal.so'
+GEOS_LIBRARY_PATH = '/app/.heroku/vendor/lib/libgeos_c.so'
+

--- a/release-tasks.sh
+++ b/release-tasks.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+python manage.py migrate

--- a/release-tasks.sh
+++ b/release-tasks.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-python manage.py migrate


### PR DESCRIPTION
This along with the Heroku python and geo buildpacks enable our PostGIS functionality on Heroku.  I'm adding a script to run setup tasks (for instance migrate) as this was not currently in place and was causing the 500 errors.  There appears from what I can tell to be an issue where python is not able to pickup GDAL and GEOS library environment variables from Heroku during the deploy phase and this is why I've added production_heroku.py with these values. I have tried setting these values in the app.json as well as the UI and it almost feels like possibly python's virtual environment cannot see them?? I'm not 100% but really it's probably not a huge deal but will continue to be on my radar.

Another note - I think we should be importing the prod db (or something sensible) into our review app's dbs so we can fully utilize this feature.  Currently the review app db is empty as you'll notice. I've checked this branch out here: https://fierce-ravine-89308.herokuapp.com/swagger/ so you can see it with data against the stage db.