### PR TITLE
Issue #226 Tweak newline handling

### DIFF
--- a/newcomers_guide/clean_data.py
+++ b/newcomers_guide/clean_data.py
@@ -4,8 +4,8 @@ import re
 def clean_up_newlines(text):
     text = remove_carriage_returns(text)
     text = remove_whitespace_between_newlines(text)
-    text = remove_whitespace_before_newline(text)
     text = remove_duplicate_space_within_lines(text)
+    text = protect_newline_after_whitespace(text)
     text = protect_newlines_around_indented_lines(text)
     text = protect_newlines_around_headings(text)
     text = protect_newlines_around_bullet_list_items(text)
@@ -30,17 +30,14 @@ def remove_duplicate_space_within_lines(text):
     return re.sub(duplicate_spaces, r'\1 ', text)
 
 
-def remove_whitespace_before_newline(text):
-    space_before_newline = r'[ \t\r]+\n'
-    return re.sub(space_before_newline, r'\n', text)
-
-
 def protect_multiple_newlines(text):
-    three_or_more_newlines = r'(\n){3,}'
-    text = re.sub(three_or_more_newlines, r'NEWLINE_MARKERNEWLINE_MARKER', text)
+    two_or_more_newlines = r'(\n){2,}'
+    return re.sub(two_or_more_newlines, r'NEWLINE_MARKERNEWLINE_MARKER', text)
 
-    two_newlines = r'(\n){2}'
-    return re.sub(two_newlines, r'NEWLINE_MARKER', text)
+
+def protect_newline_after_whitespace(text):
+    space_and_newline = r'([ \t]+)\n'
+    return re.sub(space_and_newline, r'\1NEWLINE_MARKER', text)
 
 
 def protect_newlines_around_indented_lines(text):
@@ -55,13 +52,13 @@ def protect_newlines_around_indented_lines(text):
 
 
 def protect_newlines_around_headings(text):
-    at_text_start = r'^(#[^\n]+)\n'
+    at_text_start = r'^(#[^\n]+)\n+'
     text = re.sub(at_text_start, r'\1NEWLINE_MARKER', text)
 
     at_line_start = r'\n(#[^\n])'
     text = re.sub(at_line_start, r'NEWLINE_MARKER\1', text)
 
-    at_line_end = r'(NEWLINE_MARKER#[^\n]+)\n'
+    at_line_end = r'(NEWLINE_MARKER#[^\n]+)\n+'
     return re.sub(at_line_end, r'\1NEWLINE_MARKER', text)
 
 


### PR DESCRIPTION
With this change, we avoid a lot of cleanup in the content, specifically converting `\n\n` into `\n\n\n` and `\n` into `\n\n`.