### PR TITLE
Issue #241 Add additional fields to search on at services_at_location

### DIFF
--- a/human_services/services_at_location/tests/test_api.py
+++ b/human_services/services_at_location/tests/test_api.py
@@ -53,16 +53,33 @@ class ServicesAtLocationApiTests(rest_test.APITestCase):
         self.assertEqual(json[2]['location']['name'], third_location.name)
         self.assertEqual(json[3]['location']['name'], fourth_location.name)
 
-    def test_can_full_text_search(self):
+    def test_can_full_text_search_on_service_name(self):
         service_at_locations = ServiceAtLocationBuilder().create_many()
-        expected_service_at_location = service_at_locations[0]
-        service_name = expected_service_at_location.service.name
-        location_name = expected_service_at_location.location.name
+        service_name = service_at_locations[0].service.name
         response = (self.client.get('/v1/services_at_location/?search={0}'.format(service_name)))
         json = response.json()
-        self.assertEqual(len(json), 1)
-        self.assertEqual(json[0]['location']['name'], location_name)
         self.assertEqual(json[0]['service']['name'], service_name)
+
+    def test_can_full_text_search_on_service_description(self):
+        service_at_locations = ServiceAtLocationBuilder().create_many()
+        service_description = service_at_locations[0].service.description
+        response = (self.client.get('/v1/services_at_location/?search={0}'.format(service_description)))
+        json = response.json()
+        self.assertEqual(json[0]['service']['description'], service_description)
+
+    def test_can_full_text_search_on_location_name(self):
+        service_at_locations = ServiceAtLocationBuilder().create_many()
+        location_name = service_at_locations[0].location.name
+        response = (self.client.get('/v1/services_at_location/?search={0}'.format(location_name)))
+        json = response.json()
+        self.assertEqual(json[0]['location']['name'], location_name)
+
+    def test_can_full_text_search_on_location_description(self):
+        service_at_locations = ServiceAtLocationBuilder().create_many()
+        location_description = service_at_locations[0].location.description
+        response = (self.client.get('/v1/services_at_location/?search={0}'.format(location_description)))
+        json = response.json()
+        self.assertEqual(json[0]['location']['description'], location_description)
 
     def test_can_filter_by_location_id(self):
         service_at_locations = ServiceAtLocationBuilder().create_many()

--- a/human_services/services_at_location/viewsets.py
+++ b/human_services/services_at_location/viewsets.py
@@ -11,7 +11,8 @@ from common.filters import (ProximityFilter, SearchFilter, LocationIdFilter,
 class ServiceAtLocationViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = models.ServiceAtLocation.objects.all()
     serializer_class = serializers.ServiceAtLocationSerializer
-    search_fields = ('location__translations__name', 'service__translations__name')
+    search_fields = ('location__translations__name', 'location__translations__description',
+                     'service__translations__name', 'service__translations__description')
     filter_backends = (ProximityFilter,
                        SearchFilter,
                        LocationIdFilter,


### PR DESCRIPTION
The services endpoint searches across these fields we should also be doing so at the services_at_location endpoint.