### PR TITLE
Issue #154 Pin Django to 2.1.7 to avoid Travis error "AttributeError:…

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,7 +5,7 @@ wheel==0.32.3
 six==1.12.0
 
 # django
-django>=2.1.6
+django==2.1.7
 django-environ==0.4.5
 django-model-utils==3.1.2
 django-cors-headers==2.4.0


### PR DESCRIPTION
… /usr/lib/libgdal.so.1: undefined symbol: GDALGetMetadataDomainList"