### PR TITLE
Issue #352 fix bc211 import script to return None when non-country is provided

### DIFF
--- a/bc211/importer.py
+++ b/bc211/importer.py
@@ -33,6 +33,8 @@ def handle_parser_errors(generator):
             organization = next(generator)
             organization_id = organization.id
             yield organization
+        except StopIteration:
+            return
         except XmlParseException as error:
             LOGGER.error('Error importing the organization immediately after the one with id "%s": %s',
                          organization_id, error.__str__())

--- a/bc211/parser.py
+++ b/bc211/parser.py
@@ -259,7 +259,9 @@ def parse_country(address):
         return 'CA'
     if country == 'United States':
         return 'US'
-    if country == 'All Countries':
+    if country is None:
+        return None
+    if len(country) > 2:
         return None
     return country
 

--- a/bc211/parser.py
+++ b/bc211/parser.py
@@ -259,6 +259,8 @@ def parse_country(address):
         return 'CA'
     if country == 'United States':
         return 'US'
+    if country == 'All Countries':
+        return None
     return country
 
 

--- a/bc211/tests/test_parser.py
+++ b/bc211/tests/test_parser.py
@@ -242,7 +242,7 @@ class AddressParserTests(unittest.TestCase):
                 <PhysicalAddress>
                     <Line1>Line1</Line1>
                     <City>City</City>
-                    <Country>Country</Country>
+                    <Country>Canada</Country>
                 </PhysicalAddress>
             </Site>'''
         root = etree.fromstring(xml_address)
@@ -258,7 +258,7 @@ class AddressParserTests(unittest.TestCase):
                 <MailingAddress>
                     <Line1>Line1</Line1>
                     <City>City</City>
-                    <Country>Country</Country>
+                    <Country>Canada</Country>
                 </MailingAddress>
             </Site>'''
         root = etree.fromstring(xml_address)
@@ -273,7 +273,7 @@ class AddressParserTests(unittest.TestCase):
             <Site>
                 <MailingAddress>
                     <City>City</City>
-                    <Country>Country</Country>
+                    <Country>Canada</Country>
                 </MailingAddress>
             </Site>'''
         root = etree.fromstring(xml_address)

--- a/bc211/tests/test_parser.py
+++ b/bc211/tests/test_parser.py
@@ -308,7 +308,7 @@ class AddressParserTests(unittest.TestCase):
         address = parser.parse_address(root.find('PhysicalAddress'), a_string(), 'physical_address')
         self.assertEqual(address.country, 'US')
 
-    def test_fails_silently_on_non_country(self):
+    def test_sets_address_to_none_on_invalid_country(self):
         xml_address = '''
             <Site>
                 <PhysicalAddress>

--- a/bc211/tests/test_parser.py
+++ b/bc211/tests/test_parser.py
@@ -321,7 +321,7 @@ class AddressParserTests(unittest.TestCase):
         address = parser.parse_address(root.find('PhysicalAddress'), a_string(), 'physical_address')
         self.assertIsNone(address)
 
-    def test_fails_silently_on_empty_city(self):
+    def test_sets_city_to_none_when_empty(self):
         xml_address = '''
             <Site>
                 <MailingAddress>
@@ -335,7 +335,7 @@ class AddressParserTests(unittest.TestCase):
         site_id = a_string()
         self.assertIsNone(parser.parse_address(root.find('MailingAddress'), site_id, address_type_id))
 
-    def test_fails_silently_on_missing_city(self):
+    def test_sets_city_to_none_when_missing(self):
         xml_address = '''
             <Site>
                 <MailingAddress>
@@ -348,7 +348,7 @@ class AddressParserTests(unittest.TestCase):
         site_id = a_string()
         self.assertIsNone(parser.parse_address(root.find('MailingAddress'), site_id, address_type_id))
 
-    def test_fails_silently_on_empty_country(self):
+    def test_sets_country_to_none_when_empty(self):
         xml_address = '''
             <Site>
                 <MailingAddress>
@@ -362,7 +362,7 @@ class AddressParserTests(unittest.TestCase):
         site_id = a_string()
         self.assertIsNone(parser.parse_address(root.find('MailingAddress'), site_id, address_type_id))
 
-    def test_fails_silently_on_missing_country(self):
+    def test_sets_country_to_none_when_missing(self):
         xml_address = '''
             <Site>
                 <MailingAddress>
@@ -397,7 +397,7 @@ class AddressLineParserTests(unittest.TestCase):
         address_lines = parser.parse_address_lines(root.find('MailingAddress'))
         self.assertEqual(address_lines, 'Line1\nLine2\nLine3\nLine4\nLine5\nLine6\nLine7\nLine8\nLine9')
 
-    def test_fails_silently_on_empty_address_line(self):
+    def test_sets_address_to_none_when_empty(self):
         xml_address = '''
             <Site>
                 <MailingAddress>

--- a/bc211/tests/test_parser.py
+++ b/bc211/tests/test_parser.py
@@ -308,6 +308,19 @@ class AddressParserTests(unittest.TestCase):
         address = parser.parse_address(root.find('PhysicalAddress'), a_string(), 'physical_address')
         self.assertEqual(address.country, 'US')
 
+    def test_fails_silently_on_non_country(self):
+        xml_address = '''
+            <Site>
+                <PhysicalAddress>
+                    <Line1>Line1</Line1>
+                    <City>City</City>
+                    <Country>All Countries</Country>
+                </PhysicalAddress>
+            </Site>'''
+        root = etree.fromstring(xml_address)
+        address = parser.parse_address(root.find('PhysicalAddress'), a_string(), 'physical_address')
+        self.assertIsNone(address)
+
     def test_fails_silently_on_empty_city(self):
         xml_address = '''
             <Site>


### PR DESCRIPTION
Also in this PR is a fix for Python 3.7. I was receiving this when running tests “RuntimeError: generator raised StopIteration”. 

More details here: https://docs.python.org/3/whatsnew/3.7.html
