### PR TITLE
Feature/issue 500 upgrade libraries

### DIFF
--- a/bc211/parser.py
+++ b/bc211/parser.py
@@ -251,7 +251,8 @@ def record_is_confidential(record):
     return True
 
 def parse_address_lines(address):
-    sorted_address_children = sorted(address.getchildren(), key=lambda child: child.tag)
+    address_children = list(address)
+    sorted_address_children = sorted(address_children, key=lambda child: child.tag)
     address_line_tags = [child.tag for child in sorted_address_children if re.match('Line[1-9]', child.tag)]
     if not address_line_tags:
         return None

--- a/bc211/tests/test_management.py
+++ b/bc211/tests/test_management.py
@@ -1,7 +1,7 @@
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.test import TestCase
-from django.utils.six import StringIO
+from six import StringIO
 
 ONE_AGENCY_FIXTURE = 'bc211/data/BC211_data_one_agency.xml'
 MULTI_AGENCY_FIXTURE = 'bc211/data/BC211_data_excerpt.xml'

--- a/config/urls.py
+++ b/config/urls.py
@@ -21,39 +21,39 @@ from push_notifications.view_sets import create_or_update_push_notification_toke
 def build_router():
     router = routers.DefaultRouter()
 
-    router.register(r'organizations', OrganizationViewSet, base_name='organization')
+    router.register(r'organizations', OrganizationViewSet, basename='organization')
     router.register(r'organizations/(?P<organization_id>[\w-]+)/locations',
-                    LocationViewSetUnderOrganizations, base_name='organization-location')
-    router.register(r'organizations/(?P<organization_id>[\w-]+)/services', ServiceViewSet, base_name='service')
+                    LocationViewSetUnderOrganizations, basename='organization-location')
+    router.register(r'organizations/(?P<organization_id>[\w-]+)/services', ServiceViewSet, basename='service')
     router.register(r'organizations/(?P<organization_id>[\w-]+)/locations/(?P<location_id>[\w-]+)/services',
-                    ServiceViewSet, base_name='service')
-    router.register(r'services', ServiceViewSet, base_name='service')
+                    ServiceViewSet, basename='service')
+    router.register(r'services', ServiceViewSet, basename='service')
     router.register(r'services/(?P<service_id>[\w-]+)/services_at_location', ServiceAtLocationViewSet)
     router.register(r'services/(?P<service_id>[\w-]+)/locations/(?P<location_id>[\w-]+)/services_at_location',
                     ServiceAtLocationViewSet)
-    router.register(r'services/(?P<service_id>[\w-]+)/related_topics', ServiceTopicsViewSet, base_name='topics')
-    router.register(r'locations', LocationViewSet, base_name='location')
-    router.register(r'locations/(?P<location_id>[\w-]+)/services', ServiceViewSet, base_name='service')
+    router.register(r'services/(?P<service_id>[\w-]+)/related_topics', ServiceTopicsViewSet, basename='topics')
+    router.register(r'locations', LocationViewSet, basename='location')
+    router.register(r'locations/(?P<location_id>[\w-]+)/services', ServiceViewSet, basename='service')
     router.register(r'locations/(?P<location_id>[\w-]+)/organizations/(?P<organization_id>[\w-]+)/services',
-                    ServiceViewSet, base_name='service')
+                    ServiceViewSet, basename='service')
     router.register(r'locations/(?P<location_id>[\w-]+)/services_at_location', ServiceAtLocationViewSet)
     router.register(r'locations/(?P<location_id>[\w-]+)/services/(?P<service_id>[\w-]+)/services_at_location',
                     ServiceAtLocationViewSet)
-    router.register(r'services_at_location', ServiceAtLocationViewSet, base_name='services_at_location')
-    router.register(r'topics', TopicViewSet, base_name='topics')
-    router.register(r'topics/(?P<topic_id>[\w-]+)/related_topics', RelatedTopicsViewSet, base_name='topics')
-    router.register(r'topics/(?P<topic_id>[\w-]+)/related_services', RelatedServicesViewSet, base_name='topics')
+    router.register(r'services_at_location', ServiceAtLocationViewSet, basename='services_at_location')
+    router.register(r'topics', TopicViewSet, basename='topics')
+    router.register(r'topics/(?P<topic_id>[\w-]+)/related_topics', RelatedTopicsViewSet, basename='topics')
+    router.register(r'topics/(?P<topic_id>[\w-]+)/related_services', RelatedServicesViewSet, basename='topics')
 
     return router
 
 
 def build_qa_tool_routes():
     router = routers.DefaultRouter()
-    router.register(r'algorithms', AlgorithmViewSet, base_name='algorithms')
+    router.register(r'algorithms', AlgorithmViewSet, basename='algorithms')
     router.register(r'algorithms/(?P<algorithm_id>[\w-]+)/relevancyscores',
-                    RelevancyScoreViewSet, base_name='relevancyscores')
-    router.register(r'searchlocations', SearchLocationViewSet, base_name='searchlocations')
-    router.register(r'relevancyscores', RelevancyScoreViewSet, base_name='relevancyscores')
+                    RelevancyScoreViewSet, basename='relevancyscores')
+    router.register(r'searchlocations', SearchLocationViewSet, basename='searchlocations')
+    router.register(r'relevancyscores', RelevancyScoreViewSet, basename='relevancyscores')
 
     return router
 

--- a/human_services/services_at_location/tests/test_api.py
+++ b/human_services/services_at_location/tests/test_api.py
@@ -223,10 +223,10 @@ class ServicesAtLocationApiTests(rest_test.APITestCase):
         self.assertEqual(json[1]['service']['name'], dissimilar_service.name)
 
     def test_orders_by_distance_to_user_location(self):
-        latitude = 0
-        user_longitude = 0
-        near_longitude = 0.0001
-        far_longitude = 0.0002
+        latitude = 0.0001
+        user_longitude = 0.0001
+        near_longitude = 0.0002
+        far_longitude = 0.0003
 
         far_location = (LocationBuilder(self.organization).
                         with_long_lat(far_longitude, latitude).

--- a/newcomers_guide/tests/test_review_data.py
+++ b/newcomers_guide/tests/test_review_data.py
@@ -33,7 +33,7 @@ class CompareDataForReviewTests(TestCase):
         target_text = 'Heading'
         reference_text = '# Heading'
         result = compare_data(target_text, reference_text)
-        self.assertRegexpMatches(result, r'contains 0 headings, reference has 1')
+        self.assertRegex(result, r'contains 0 headings, reference has 1')
 
     def test_ignores_matching_heading(self):
         target_text = 'some text.\n#Heading'
@@ -45,13 +45,13 @@ class CompareDataForReviewTests(TestCase):
         target_text = 'some text.\nHeading'
         reference_text = 'some text.\n#Heading'
         result = compare_data(target_text, reference_text)
-        self.assertRegexpMatches(result, r'contains 0 headings, reference has 1')
+        self.assertRegex(result, r'contains 0 headings, reference has 1')
 
     def test_detects_extra_heading(self):
         target_text = 'some text.\n#Heading'
         reference_text = 'some text.\nHeading'
         result = compare_data(target_text, reference_text)
-        self.assertRegexpMatches(result, r'contains 1 headings, reference has 0')
+        self.assertRegex(result, r'contains 1 headings, reference has 0')
 
     def test_ignores_hash_signs_within_lines(self):
         target_text = 'foo bar baz'

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 # Package management
-wheel==0.33.4
+wheel==0.33.6
 
 # python 2 compatibility
 six==1.13.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,7 @@ django-environ==0.4.5
 django-model-utils==4.0.0
 django-cors-headers==3.2.0
 django-parler==2.0
-djangorestframework==3.9.4
+djangorestframework==3.11.0
 drf_yasg==1.15.0
 awesome-slugify==1.6.5
 polib==1.1.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,7 +9,7 @@ django==3.0.1
 django-environ==0.4.5
 django-model-utils==4.0.0
 django-cors-headers==3.2.0
-django-parler==1.9.2
+django-parler==2.0
 djangorestframework==3.9.4
 drf_yasg==1.15.0
 awesome-slugify==1.6.5

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,7 +2,7 @@
 wheel==0.33.4
 
 # python 2 compatibility
-six==1.12.0
+six==1.13.0
 
 # django
 django==3.0.1

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,7 +9,7 @@ django==3.0.1
 django-environ==0.4.5
 django-model-utils==4.0.0
 django-cors-headers==3.2.0
-django-parler==2.0
+django-parler==2.0.1
 djangorestframework==3.11.0
 drf_yasg==1.15.0
 awesome-slugify==1.6.5

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -38,8 +38,8 @@ msgpack==0.6.1
 whitenoise==4.1.2
 
 # caching
-django-redis==4.10.0
-redis==3.2.1
+django-redis==4.11.0
+redis==3.3.11
 
 # front end tech, TODO remove
 django-crispy-forms==1.7.2

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,7 +8,7 @@ six==1.13.0
 django==3.0.1
 django-environ==0.4.5
 django-model-utils==4.0.0
-django-cors-headers==3.0.1
+django-cors-headers==3.2.0
 django-parler==1.9.2
 djangorestframework==3.9.4
 drf_yasg==1.15.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -28,9 +28,9 @@ exponent-server-sdk==0.3.1
 psycopg2==2.8.2 --no-binary psycopg2
 
 # Natural language processing
-spacy==2.1.4
-scipy==1.3.0
-textacy==0.7.0
+spacy==2.2.3
+scipy==1.4.1
+textacy==0.9.1
 # see https://github.com/explosion/spaCy/issues/2995, resolves error "ValueError: 1792000 exceeds max_bin_len(1048576)"
 msgpack==0.6.1
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,7 +7,7 @@ six==1.13.0
 # django
 django==3.0.1
 django-environ==0.4.5
-django-model-utils==3.1.2
+django-model-utils==4.0.0
 django-cors-headers==3.0.1
 django-parler==1.9.2
 djangorestframework==3.9.4

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,7 +5,7 @@ wheel==0.33.4
 six==1.12.0
 
 # django
-django==2.2.4
+django==3.0.1
 django-environ==0.4.5
 django-model-utils==3.1.2
 django-cors-headers==3.0.1


### PR DESCRIPTION
This PR is blocked by django-parler. 

As discussed here https://docs.djangoproject.com/en/3.0/releases/3.0/#removed-private-python-2-compatibility-apis:

> django.utils.six and django.utils.encoding.python_2_unicode_compatible are removed in django 3.

Django-parler currently imports six from django.utils and we currently receive this error every time we run the tests. : 

> ImportError: cannot import name 'six' from 'django.utils' (/Users/tomyreyes/Desktop/pathways-backend/.venv/lib/python3.7/site-packages/django/utils/__init__.py)

The maintainers of django-parler have recently dropped their use of six and currently have the changes in their master branch. Will we have to wait until a stable version of django-parler is released with these changes. Discussion on this issue can be found here:
https://github.com/django-parler/django-parler/pull/255

Along with upgrading the libraries, there have been some small changes made in a couple of files because of code becoming deprecated. 

Django's documentation recommends running `python3 -Wa ./manage.py test` for the purposes of removing deprecated code along with becoming familiar with new changes. 